### PR TITLE
Rat

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Bump version
 
 on:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -14,12 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Bump version
+name: Bump Version
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["Release Audit Tool"]
+    types:
+      - completed
 
 jobs:
   bump-version:

--- a/.github/workflows/pytest_publish.yml
+++ b/.github/workflows/pytest_publish.yml
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Upload Python Package to PyPI Test
 
 on:

--- a/.github/workflows/pytest_publish.yml
+++ b/.github/workflows/pytest_publish.yml
@@ -17,13 +17,13 @@
 name: Upload Python Package to PyPI Test
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["Bump Version"]
+    types:
+      - completed
 
 jobs:
   publish-test-pypi:
-    if: github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -17,7 +17,12 @@
 name: Release Audit Tool
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Test Suite"]
+    types:
+      - completed
+    branches:
+      - "master"
     tags:
       - "v*"
 

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Upload Python Package to PyPI Test
+name: Release Audit Tool
 
 on:
   push:
@@ -22,8 +22,7 @@ on:
       - "v*"
 
 jobs:
-  publish-test-pypi:
-    if: github.event.pull_request.merged
+  rat:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -43,11 +42,22 @@ jobs:
         run: |
           poetry --version
           poetry install
-      - name: Build and publish
-        env:
-          PYPI_USERNAME: __token__
-          PYPI_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      - name: Build
+        run: poetry build
+      - name: Checkout RAT
+        uses: actions/checkout@v3
+        with:
+          repository: 'apache/creadur-rat'
+          ref: 'apache-rat-project-0.15'
+          path: 'rat'
+      - name: Setup Maven
+        uses: s4u/setup-maven-action@v1.9.0
+        with:
+          java-version: 17
+          checkout-path: maven
+      - name: Install RAT
         run: |
-          poetry config repositories.testpypi https://test.pypi.org/legacy/
-          poetry config http-basic.testpypi $PYPI_USERNAME $PYPI_PASSWORD
-          make publish_pytest
+          cd rat/apache-rat
+          mvn clean install
+      - name: Run RAT
+        run: java -jar rat/apache-rat/target/apache-rat-0.15.jar -d dist/flagon_distill-*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,19 @@ on:
   pull_request:
     branches:
       - dev
+      - master
   push:
     branches:
       - dev
+      - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - name: Checkout code

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,18 +1,18 @@
 
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 Sphinx==1.6.3
 sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
Changes in this PR:
- introduces a new GitHub action to check release tags with the Apache release audit tool. 
- fixes some license issues.
- Changes the pytest job to a tag trigger.

I've also checked that all the licenses of the third party GitHub actions are permissible.

Ideally the shared steps in the RAT workflow and the PyTest workflow would be abstracted to a third, callable workflow. But I couldn't get that working.